### PR TITLE
Fix : Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Please fill out [this request form](https://docs.google.com/forms/d/e/1FAIpQLSck
 * CNCF and Bevy have organized the training session for the Community Groups organizers. It has been recorded and now [available on YouTube](https://www.youtube.com/watch?v=_rBdomoYlmc).
 * You can also access the Bevy Help Portal at <https://help.bevylabs.com/>.
 * [Bevy FAQ can be found here](https://github.com/cncf/communitygroups/blob/main/FAQ.md).
-* If you want to test video features, you can use: https://tokbox.com/developer/tools/precall/
+* If you want to test video features, you can use: [https://tokbox.com/developer/tools/precall/](https://tokbox.com/developer/tools/precall/)
 
 ### Support
 
-- If you have any technical difficulties with the platform itself, please reach out to the [Bevy platform support by clicking the purple question mark in the bottom right corner of your Bevy chapter dashboard.
+- If you have any technical difficulties with the platform itself, please reach out to the Bevy platform support by clicking the purple question mark in the bottom right corner of your Bevy chapter dashboard.
 - Troubleshooting: The troubleshooting guide by Bevy is available here: [help.bevylabs.com/article/499-troubleshooting](https://help.bevylabs.com/article/499-troubleshooting)
 - Last resort, you can reach out to Audra Montenegro in the CNCF Slack workspace to help you, especially if it is time senstive.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please fill out [this request form](https://docs.google.com/forms/d/e/1FAIpQLSck
 * CNCF and Bevy have organized the training session for the Community Groups organizers. It has been recorded and now [available on YouTube](https://www.youtube.com/watch?v=_rBdomoYlmc).
 * You can also access the Bevy Help Portal at <https://help.bevylabs.com/>.
 * [Bevy FAQ can be found here](https://github.com/cncf/communitygroups/blob/main/FAQ.md).
-* If you want to test video features, you can use: [https://tokbox.com/developer/tools/precall/](https://tokbox.com/developer/tools/precall/)
+* If you want to test video features, you can use: <https://tokbox.com/developer/tools/precall/>
 
 ### Support
 


### PR DESCRIPTION
Fix typo for bevy, remove the "before" brackets
Set url for https://tokbox.com/developer/tools/precall/