### PR TITLE
Fix vendor neutrality typo even more

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-group-request.yaml
+++ b/.github/ISSUE_TEMPLATE/new-group-request.yaml
@@ -98,9 +98,9 @@ body:
   type: checkboxes
   attributes:
     label: Vendor Neutral
-    description: "CNCGs should have vendor-nuetral content for the main portion of your meetups. Please note that [sponsors can have up to 15 minutes on stage](https://github.com/cncf/communitygroups/blob/main/best_practices.md#sponsorships)"
+    description: "CNCGs should have vendor-neutral content for the main portion of your meetups. Please note that [sponsors can have up to 15 minutes on stage](https://github.com/cncf/communitygroups/blob/main/best_practices.md#sponsorships)"
     options:
-      - label: I/We have read what [vendor-nuetrality means](https://contribute.cncf.io/maintainers/community/vendor-neutrality/), and agree that the main content of our meetups will remain vendor-nuetral
+      - label: I/We have read what [vendor-neutrality means](https://contribute.cncf.io/maintainers/community/vendor-neutrality/), and agree that the main content of our meetups will remain vendor-neutral
         required: true
 - id: organizer_branding
   type: checkboxes

--- a/.github/ISSUE_TEMPLATE/organizer-request.yml
+++ b/.github/ISSUE_TEMPLATE/organizer-request.yml
@@ -71,7 +71,7 @@ body:
     label: Vendor Neutral
     description: "CNCGs should have vendor-neutral content for the main portion of your meetups. Please note that [sponsors can have up to 15 minutes on stage](https://github.com/cncf/communitygroups/blob/main/best_practices.md#sponsorships)"
     options:
-      - label: I have read what [vendor-neutrality means](https://contribute.cncf.io/maintainers/community/vendor-neutrality/), and I agree the main content of our meetups will remain vendor-nuetral (do not mark if not relevant to request)
+      - label: I have read what [vendor-neutrality means](https://contribute.cncf.io/maintainers/community/vendor-neutrality/), and I agree the main content of our meetups will remain vendor-neutral (do not mark if not relevant to request)
         required: false
 - id: organizer_activity
   type: checkboxes


### PR DESCRIPTION
In https://github.com/cncf/communitygroups/pull/305 not all typos had been caught.
Fixed them now in the new group request as well as the one remaining typo in the organizer request.