### PR TITLE
Added distinction for Technical Working Groups

### DIFF
--- a/.github/ISSUE_TEMPLATE/regional-group-application.yaml
+++ b/.github/ISSUE_TEMPLATE/regional-group-application.yaml
@@ -48,14 +48,14 @@ body:
     placeholder: e.g. Audra Montenegro, CNCF, https://github.com/AudMonte01, https://www.linkedin.com/in/audramontenegro/, Audra Montenegro in CNCF Slack, https://community.cncf.io/u/m8bqcv/#/about
   validations:
     required: false
-- id: content
+- id: meetupDOTcom
   type: textarea
   attributes:
     label: If you already run a meetup, please link it here
     placeholder: e.g. https://www.meetup.com/bay-area-kubernetes-meetup/
   validations:
     required: false
-- id: meetupDOTcom
+- id: content
   type: textarea
   attributes:
     label: What is your mission statement or objective for this new chapter?
@@ -66,7 +66,7 @@ body:
   type: checkboxes
   attributes:
     label: Code of Conduct
-    description: "The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it, including any and all futre speakers and future co-organizers."
+    description: "The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it, including any and all future speakers and future co-organizers."
     options:
       - label: I/We agree to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
         required: true

--- a/.github/ISSUE_TEMPLATE/technical-group-application.yaml
+++ b/.github/ISSUE_TEMPLATE/technical-group-application.yaml
@@ -1,0 +1,126 @@
+name: Technical Community Group Request
+description: Request to create a new Cloud Native Community Group by topic
+title: "[TCG Request] <Group Topic>"
+body:
+- type: markdown
+  attributes:
+    value: |
+      ### Please Read:
+      
+      :loudspeaker: Prior to filling out the below form, please check [community.cncf.io](https://community.cncf.io) to confirm there isn't an active Technical Community Group for this topic. 
+      
+      If there is an active group close to this space, we recommend collaborating with the current organizers. If there is a deactivated group, please reach out to community-groups@cncf.io, or [file an organizer issue here](https://github.com/cncf/communitygroups/issues/new?assignees=&labels=&projects=&template=organizer-request.yml&title=%5BOrganizer+Request%5D+Add+or+Remove+Organizer+Name). :loudspeaker:
+
+      Additionally, check all [open issues](https://github.com/cncf/communitygroups/issues) to ensure there isn't an open request for this topic already. If there is an open ticket, please comment within that GitHub issue with your interest to co-organize.
+
+      If you have checked all the above areas and there is no active chapter or open GitHub issues, fill out the form for our team to review.
+- type: input
+  id: name
+  attributes:
+    label: Topic of this CNCG
+    placeholder: e.g. Cloud Native San Francisco
+  validations:
+    required: true
+- id: content
+  type: textarea
+  attributes:
+    label: What is your mission statement or objective for this new chapter?
+    placeholder: e.g. We’re excited about microservices, containers, the distributions that run them and the solutions that deploy, manage, and extend them. Any skill level is welcome; we’re all new to Kubernetes and we want to create an open, welcoming environment for other Kubernauts.
+  validations:
+    required: true
+- id: organizer_1
+  type: textarea
+  attributes:
+    label: Tell us about yourself. List your name, email, company, GitHub URL, LinkedIn URL, and CNCF Slack workspace name (or if you need to be invited), and a required profile link on community.cncf.io
+    placeholder: e.g. Audra Montenegro, CNCF, https://github.com/AudMonte01, https://www.linkedin.com/in/audramontenegro/, Audra Montenegro in CNCF Slack, https://community.cncf.io/u/m8bqcv/#/about
+  validations:
+    required: true
+- id: organizer_2
+  type: textarea
+  attributes:
+    label: Tell us about your co-organizer. List their name, email, company, GitHub URL, LinkedIn URL, and CNCF Slack workspace name (or if they need to be invited), and a required profile link on community.cncf.io
+    placeholder: e.g. Audra Montenegro, CNCF, https://github.com/AudMonte01, https://www.linkedin.com/in/audramontenegro/, Audra Montenegro in CNCF Slack, https://community.cncf.io/u/m8bqcv/#/about
+  validations:
+    required: false
+- id: organizer_3
+  type: textarea
+  attributes:
+    label: Tell us about your co-organizer. List their name, email, company, GitHub URL, LinkedIn URL, and CNCF Slack workspace name (or if they need to be invited), and a required profile link on community.cncf.io
+    placeholder: e.g. Audra Montenegro, CNCF, https://github.com/AudMonte01, https://www.linkedin.com/in/audramontenegro/, Audra Montenegro in CNCF Slack, https://community.cncf.io/u/m8bqcv/#/about
+  validations:
+    required: false
+- id: meetupDOTcom
+  type: textarea
+  attributes:
+    label: If you already lead another group, please link it here
+    placeholder: e.g. https://www.meetup.com/bay-area-kubernetes-meetup/
+  validations:
+    required: false
+- id: organizer_coc
+  type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: "The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it, including any and all future speakers and future co-organizers."
+    options:
+      - label: We agree to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+        required: true
+- id: organizer_affiliation
+  type: checkboxes
+  attributes:
+    label: Organizer affiliations
+    description: "There must be at least 2 organizers with different affiliations."
+    options:
+      - label: The organizers affirm that two or more are from different affiliations
+        required: true
+- id: organizer_inclusivity
+  type: checkboxes
+  attributes:
+    label: Inclusive
+    description: "You agree to be inclusive of all people eager to learn about cloud native, no matter what level of expertise they are at in their open source journey."
+    options:
+      - label: We agree. To assure this, We have recently completed the [Inclusive Open Source Community Orientation (LFC102) course](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/)
+        required: true
+- id: organizer_neutrality
+  type: checkboxes
+  attributes:
+    label: Vendor Neutral
+    description: "CNCGs should have vendor-neutral content for the main portion of your meetups. Please note that [sponsors can have up to 15 minutes on stage](https://github.com/cncf/communitygroups/blob/main/best_practices.md#sponsorships)"
+    options:
+      - label: We have read what [vendor-neutrality means](https://contribute.cncf.io/maintainers/community/vendor-neutrality/), and agree that the main content of our meetups will remain vendor-neutral
+        required: true
+- id: organizer_branding
+  type: checkboxes
+  attributes:
+    label: Agree to use CNCG branding
+    description: "In an effort to avoid trademark miss-use, and have unity within the CNCG program, you agree to use [CNCG branding](https://github.com/cncf/artwork/blob/main/examples/other.md#cloud-native-community-groups)."
+    options:
+      - label: We agree to use the CNCG logo in my/our chapter and social branding
+        required: true
+- id: organizer_registration
+  type: checkboxes
+  attributes:
+    label: Registration through CNCF platforms
+    description: "In order to properly support your chapter with benefits, registration for all events must be through CNCF platforms, or the current CNCF community platform."
+    options:
+      - label: We agree to host free registration in the main CNCF platform
+        required: true
+- id: organizer_activity
+  type: checkboxes
+  attributes:
+    label: Remain an active chapter
+    description: "While virtual meetings every 30 days is recommended, you agree to host a meetup, study group, or virtual event [at least 1 time every 90 days (quarter)](https://github.com/cncf/communitygroups/blob/main/README.md#community-group-inactivity). And if you foresee a delay, you will notify the CNCF team via community-groups@cncf.io"
+    options:
+      - label: We agree to have a meetup at least once every 90 days, or else communicate reasoning for upcoming inactivity.
+        required: true
+- id: organizer_diversity
+  type: checkboxes
+  attributes:
+    label: Aim to have a diverse representation of speakers in your events
+    description: "Diversity means something different for each country. The commonality among all countries is to strive to promote women or non-male speakers."
+    options:
+      - label: We will do our best to host diverse speakers throughout the year
+        required: true
+- type: markdown
+  attributes:
+    value: |
+      ### Review of your chapter request can take up to 30 days, as our team performs our due diligence. If you have questions throughout the process, please comment within your GitHub issue.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Cloud Native Community Groups
 
-* [Program description](#program-description)
-* [Benefits of joining the CNCF Community Groups Program](#benefits-of-joining-the-cncf-community-groups-program)
-* [Best practices](https://github.com/cncf/communitygroups/blob/main/best_practices.md)
-* [How to apply/get started](#how-to-apply)
-* [Bevy training and support](#bevy-training)
-* [Communication](#communication)
-* [Marketing Best Practices and Resources](#marketing-best-practices-and-resources)
-* [Naming your chapter](#naming-your-chapter)
-* [Chapter Activity](#community-group-inactivity)
-* [Code of Conduct](#code-of-conduct)
+- [Program description](#program-description)
+- [Benefits of joining the CNCF Community Groups Program](#benefits-of-joining-the-cncf-community-groups-program)
+- [Best practices](https://github.com/cncf/communitygroups/blob/main/best_practices.md)
+- [How to apply/get started](#how-to-apply)
+- [Bevy training and support](#bevy-training)
+- [Communication](#communication)
+- [Marketing Best Practices and Resources](#marketing-best-practices-and-resources)
+- [Naming your chapter](#naming-your-chapter)
+- [Chapter Activity](#community-group-inactivity)
+- [Code of Conduct](#code-of-conduct)
 
 ## Program description
 
@@ -18,9 +18,18 @@ CNCF is currently working on expanding the Cloud Native community worldwide, and
 If you are interested in joining the list of official CNCF Community Groups, please review the information below.
 As of 2021, Cloud Native Community Groups program is powered by the Bevy platform, and managed by the CNCF staff.
 
+### Technical Community Groups
+
+A [Technical Community Group](https://github.com/cncf/toc/blob/main/governance/tag-governance.md#technical-community-groups) is focused primarily on identifying and discussing a particular technical scope, technology, or problem space. This type of community group is expected to have one or more monthly virtual meetings, and may also have in-person meetups.
+
+### Regional Community Groups
+
+A Regional Community Group is the long-standing, traditional type of community group in CNCF. This type of group is primarily focused on building relationships among cloud native end users and contributors in a particular region. It is expected to have one or more in-person meetups per year, and may also have virtual meetings.
+
 ## Benefits of joining the CNCF Community Groups Program
 
 For all Cloud Native Community Groups, CNCF offers the following benefits:
+
 - One-time complimentary swag coupon of $100 USD to the CNCF Store provided to each community group (not to each organizer), is available after hosting 2 successful (over 10 people attended) in-person events per chapter within 3 months or 90 days. NOTE: Registration must happen within the Bevy platform for this coupon to be earned. Requesting your voucher - write to community-groups@cncf.io with a link to your past Bevy event pages. We will make an exception for virtual events, if your event has over 100 attendees.
 - Joining the CNCF organizer-exclusive Slack channel for collaboration
 - Boosting the visibility of your community group and events. See below under the “Communication” section for more details.
@@ -43,15 +52,14 @@ Please check out our [best_practices](./best_practices.md).
 
 Applications can now be submitted via a [GitHub issue](https://github.com/cncf/communitygroups/issues/new?assignees=&labels=&projects=&template=new-group-request.yaml&title=%5BGroup+Request%5D+Create+a+new+chapter). Once a GitHub issue will be filled, there will be a 30-day grace period. If you do not hear back after that amount of time has passed, please reach out to community-groups@cncf.io.
 
-
 ## Bevy Training
 
 Bevy is the platform that backs community.cncf.io. With over 190 ACTIVE chapters (as of 2024), Bevy allows for in-person and virtual meetups, co-hosting, emailing your attendees, transparent analytics for organizers, and a microsite (small website) that can feature sponsors, speakers, and more!
 
-* CNCF and Bevy have organized the training session for the Community Groups organizers. It has been recorded and now [available on YouTube](https://www.youtube.com/watch?v=_rBdomoYlmc).
-* You can also access the Bevy Help Portal at <https://help.bevylabs.com/>.
-* [Bevy FAQ can be found here](https://github.com/cncf/communitygroups/blob/main/FAQ.md).
-* If you want to test video features, you can use: <https://tokbox.com/developer/tools/precall/>
+- CNCF and Bevy have organized the training session for the Community Groups organizers. It has been recorded and now [available on YouTube](https://www.youtube.com/watch?v=_rBdomoYlmc).
+- You can also access the Bevy Help Portal at <https://help.bevylabs.com/>.
+- [Bevy FAQ can be found here](https://github.com/cncf/communitygroups/blob/main/FAQ.md).
+- If you want to test video features, you can use: <https://tokbox.com/developer/tools/precall/>
 
 ### Support
 
@@ -68,13 +76,15 @@ Please use "Cloud Native CITY NAME" when naming your chapter. We ask that you av
 ## Communication
 
 We strive to keep all organizers as up to date as possible when it comes to program updates and changes. Here are a few ways you can stay in the loop:
-* Subscribe to our global organizer newsletter by going to your [community profile and then "updates"](https://community.cncf.io/accounts/profile/#updates). There you can opt-in by marking the "Global" checkbox under the "Receive general communications from" header.
-* Please reach out to us on the #communitygroups channel on the CNCF slack. Please avoid using direct messages unless strictly necessary as doing so both has the potential of overwhelming project maintainers and others with similar questions lose the benefit of public discussion.
-* It's best if you use a public communication channel whenever possible; however, if you need to communicate in private, please feel free to send the program admins a note via community-groups@cncf.io (please use the public channels for any program-related discussion).
+
+- Subscribe to our global organizer newsletter by going to your [community profile and then "updates"](https://community.cncf.io/accounts/profile/#updates). There you can opt-in by marking the "Global" checkbox under the "Receive general communications from" header.
+- Please reach out to us on the #communitygroups channel on the CNCF slack. Please avoid using direct messages unless strictly necessary as doing so both has the potential of overwhelming project maintainers and others with similar questions lose the benefit of public discussion.
+- It's best if you use a public communication channel whenever possible; however, if you need to communicate in private, please feel free to send the program admins a note via community-groups@cncf.io (please use the public channels for any program-related discussion).
 
 ## Marketing Best Practices and Resources
 
 ### Social Media
+
 We encourage each chapter to create their own social media accounts on the platforms that are most relevant in their local area, in addition to LinkedIn so CNCF can properly help amplify your announcements.
 
 CNCF is present on [Twitter (X)](https://twitter.com/CloudNativeFdn) and [LinkedIn](https://www.linkedin.com/company/cloud-native-computing-foundation/mycompany/) with over 100,000 followers on each. If you are a CNCF chapter promoting your community on community.cncf.io, then CNCF will be happy to help you promote your meetups on social media. Simply join the [#socialmedia channel in the CNCF Slack workspace](https://cloud-native.slack.com/archives/C12MRQ97A), and tag Jessie Adams-Shore asking her to re-share your post. Each CNCG is limited to one post amplification per week. NOTE: In the spirit of vendor neutrality, CNCF will not amplify sponsor posts.
@@ -82,32 +92,42 @@ CNCF is present on [Twitter (X)](https://twitter.com/CloudNativeFdn) and [Linked
 IMPORTANT: Every LinkedIn page created should be created as a company page, and must add CNCF's core community program manager, Audra Montenegro as an admin.
 
 ### Common things to promote in your meetups
-* Speakers and their content! This is the most attractive thing to your audience
-* The details! Tell people when, where, and the location of your meetup
-* Food and beverage! What refreshments will you will be providing
-* Promote your sponsors! They will appreciate the shout out. You do this by thanking them for sponsoring your event and showcasing their logo. They also appreciate you linking to their website or their open source resource or insights (more attractive to this audience)
-* Giveaways! Not everyone will have this opportunity, over time you will generate sponsors for this, or [earn a voucher from us](benefits-of-joining-the-CNCF-community-groups-program).
+
+- Speakers and their content! This is the most attractive thing to your audience
+- The details! Tell people when, where, and the location of your meetup
+- Food and beverage! What refreshments will you will be providing
+- Promote your sponsors! They will appreciate the shout out. You do this by thanking them for sponsoring your event and showcasing their logo. They also appreciate you linking to their website or their open source resource or insights (more attractive to this audience)
+- Giveaways! Not everyone will have this opportunity, over time you will generate sponsors for this, or [earn a voucher from us](benefits-of-joining-the-CNCF-community-groups-program).
 
 ### Promotional Graphics
+
 Here we have some templates in Canva that will at least help you with sizing and placement of key content:
-* [LinkedIn and Facebook](https://www.canva.com/design/DAGDoVUWY9w/QwHhJgCuoEFvefVxQIGJ2w/view?)
-* [Twitter](https://www.canva.com/design/DAGDoQ6zx2c/5ym4UFerINEdRlgEyHmTuA/view?)
-* [Instagram](https://www.canva.com/design/DAGDoXtCdB4/CIqyQVHUcfmq_AcDswEMVw/view?)
+
+- [LinkedIn and Facebook](https://www.canva.com/design/DAGDoVUWY9w/QwHhJgCuoEFvefVxQIGJ2w/view?)
+- [Twitter](https://www.canva.com/design/DAGDoQ6zx2c/5ym4UFerINEdRlgEyHmTuA/view?)
+- [Instagram](https://www.canva.com/design/DAGDoXtCdB4/CIqyQVHUcfmq_AcDswEMVw/view?)
 
 ### Partnering with other communities
+
 This is acceptable, as long as it is a general tech community or open source community. Usually the exchange is presence at their events, and your brand recognition. CNCF just asks you do not market their events to your members.
 
 ## Community Group Inactivity
 
-If your group has more than 90 days of inactivity in the number of events/meetups being heald, then you will be deemed an “Inactive” group via the Cloud Native Computing Foundation and removed from [community.cncf.io](https://community.cncf.io/). There are many ways to keep your chapter active outside of regular in-person, speaker-to-audience meetups. Examples are:
-* Co-hosting a meetup with a neighboring chapter. [Learn about the Co-Host feature in Bevy](https://youtu.be/rEKoZ5OAGpo).
-* Host a study group for one of the many Kubernetes certifications
-* Use Bevy's virtual feature to host a virtual meetup or study group
+If your group has more than 90 days of inactivity in the number of events/meetups being held, then you will be deemed an “Inactive” group via the Cloud Native Computing Foundation and removed from [community.cncf.io](https://community.cncf.io/).
 
-Should a community group violate vendor neutrality, a CNCF core value, the following path towards deactivation will occur.
-* 1st offense = a written violation via email
-* 2nd offense = a community meeting with organizers for final warning
-* 3rd offense = disabling your chapter
+Technical Community Groups that fail to meet at least six times in a calendar year will also be considered inactive.
+
+There are many ways to keep your chapter active outside of regular in-person, speaker-to-audience meetups. Examples are:
+
+- Co-hosting a meetup with a neighboring chapter. [Learn about the Co-Host feature in Bevy](https://youtu.be/rEKoZ5OAGpo).
+- Host a study group for one of the many Kubernetes certifications
+- Use Bevy's virtual feature to host a virtual meetup or study group
+
+Should a community group violate vendor neutrality — a CNCF core value — the following path towards deactivation will occur.
+
+- 1st offense = a written violation via email
+- 2nd offense = a community meeting with organizers for final warning
+- 3rd offense = disabling your chapter
 
 ## Code of Conduct
 


### PR DESCRIPTION
Working with @mrbobbytables to ensure clarity around the new type of community group reference in the latest update from the TOC.

This PR adds language for Technical Community Groups.

I also did a bit of linting along the way, as my IDE was lit up like a christmas tree. Let me know if that damages readability of this PR and needs to be reverted.