### PR TITLE
Add Credly Badge link input to organizer request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/organizer-request.yml
+++ b/.github/ISSUE_TEMPLATE/organizer-request.yml
@@ -65,6 +65,14 @@ body:
     options:
       - label: I agree. To assure this, I have recently completed the [Inclusive Open Source Community Orientation (LFC102) course](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/) (do not mark if not relevant to request). I will comment in this issue with a link to my Credly badge proving completion of the course.
         required: false
+- id: organizer_inclusivity_badge
+  type: input
+  attributes:
+    label: Link to your LFC102 Credly Badge
+    placeholder: e.g. https://www.credly.com/badges/...
+    description: "Please paste the link to your Credly badge proving completion of the LFC102 course."
+  validations:
+    required: false
 - id: organizer_neutrality
   type: checkboxes
   attributes:


### PR DESCRIPTION
Added input field for LFC102 Credly Badge link in organizer request template.