### PR TITLE
ci(sessionize-new-proposal): deny-all permissions on the default token

### DIFF
--- a/.github/workflows/sessionize-new-proposal.yaml
+++ b/.github/workflows/sessionize-new-proposal.yaml
@@ -8,6 +8,10 @@ env:
   # Setting an environment variable with the value of a configuration variable
   SESSIONIZE_LATEST_SESSION_ID_PREVIOUS: ${{ vars.SESSIONIZE_LATEST_SESSION_ID }}
 
+# No checkout. The retrieve job hits Sessionize + Slack webhooks; the
+# update-github-variable job uses secrets.REPO_ACCESS_TOKEN (not GITHUB_TOKEN).
+permissions: {}
+
 jobs:
   retrieve-latest-session:
     name: retrieve-latest-session


### PR DESCRIPTION
Adds `permissions: {}` (deny-all) to the scheduled Sessionize sync workflow. The default `GITHUB_TOKEN` is unused:

- The `retrieve-latest-session` job calls the Sessionize public API and the Slack webhook via `SLACK_WEBHOOK_URL` — no GitHub API calls.
- The `update-github-variable` job uses `mmoyaferrer/set-github-variable` with `secrets.REPO_ACCESS_TOKEN`, a separate PAT, not the default token.
- No checkout step.

YAML validated locally.