### PR TITLE
make logo guidance discoverable for new organizers

### DIFF
--- a/.github/ISSUE_TEMPLATE/regional-group-application.yaml
+++ b/.github/ISSUE_TEMPLATE/regional-group-application.yaml
@@ -130,7 +130,7 @@ body:
   type: checkboxes
   attributes:
     label: Agree to use CNCG branding
-    description: "In an effort to avoid trademark misuse and maintain unity within the CNCG program, you agree to use [CNCG branding](https://github.com/cncf/artwork/blob/main/examples/other.md#cloud-native-community-groups)."
+    description: "In an effort to avoid trademark misuse and maintain unity within the CNCG program, you agree to use [CNCG branding](https://github.com/cncf/artwork/blob/main/examples/other.md#cloud-native-community-groups) (see also [branding.md](https://github.com/cncf/communitygroups/blob/main/branding.md) for naming conventions and other brand assets)."
     options:
       - label: I/We agree to use the CNCG logo in my/our group and social branding.
         required: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [How to apply/get started](#how-to-apply)
 - [Communication](#communication)
 - [Marketing Best Practices and Resources](#marketing-best-practices-and-resources)
+  - [Branding & Logos](#branding--logos)
 - [Naming your chapter](#naming-your-chapter)
 - [Chapter Activity](#community-group-inactivity)
 - [Code of Conduct](#code-of-conduct)
@@ -44,7 +45,12 @@ For all Cloud Native Community Groups, CNCF offers the following benefits:
 
 ## Best Practices
 
-Please check out our [best_practices](./best_practices.md).
+Please check out our [best_practices.md](./best_practices.md) guide for the full walkthrough of running a Cloud Native Community Group, including:
+
+- [Creating your group](./best_practices.md#0-create-the-cloud-native-community-group), [finding speakers](./best_practices.md#find-speakers), and [securing sponsorships](./best_practices.md#sponsorships)
+- [Scheduling](./best_practices.md#2-schedule-a-new-event), [announcing](./best_practices.md#3-announce-the-event), and [running](./best_practices.md#4-run-the-event) your event
+- [Host](./best_practices.md#cncf-community-groups---host-checklist) and [Organizer](./best_practices.md#cncf-community-groups---organizer-checklist) checklists for event day
+- [Post-event](./best_practices.md#5-post-event) follow-up and [CNCF swag](./best_practices.md#cncf-swag) eligibility
 
 ## How to apply?
 
@@ -66,6 +72,10 @@ We strive to keep all organizers as up to date as possible when it comes to prog
 
 ## Marketing Best Practices and Resources
 
+### Branding & Logos
+
+Use the official CNCG logo and add "Cloud Native [YOUR CHAPTER NAME]" underneath it. See [branding.md](./branding.md) for the logo source, naming conventions, and other brand assets (promotional graphics, recognition materials).
+
 ### Social Media
 
 We encourage each chapter to create their own social media accounts on the platforms that are most relevant in their local area, in addition to LinkedIn so CNCF can properly help amplify your announcements.
@@ -84,11 +94,7 @@ IMPORTANT: Every LinkedIn page created should be created as a company page, and 
 
 ### Promotional Graphics
 
-Here we have some templates in Canva that will at least help you with sizing and placement of key content:
-
-- [LinkedIn and Facebook](https://www.canva.com/design/DAGDoVUWY9w/95h_DM7rQsnWXWDSK2UAlQ/edit?utm_content=DAGDoVUWY9w&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton)
-- [Twitter](https://www.canva.com/design/DAGDoQ6zx2c/l2aRUC91lf0St4GTVSbYhA/edit?utm_content=DAGDoQ6zx2c&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton)
-- [Instagram](https://www.canva.com/design/DAGDoXtCdB4/XlsMHZhYCLjz05MdvyA6_w/edit?utm_content=DAGDoXtCdB4&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton)
+See [branding.md](./branding.md#promotional-graphics) for Canva templates that will help with sizing and placement of key content.
 
 ### Partnering with other communities
 

--- a/best_practices.md
+++ b/best_practices.md
@@ -27,6 +27,7 @@ Each of the steps above are now described in more detail.
 - [1. Start planning your event](#1-start-planning-you-event)
   * [Find Speakers](#find-speakers)
   * [Sponsorships](#sponsorships)
+    + [Sponsor Prospectus](#sponsor-prospectus)
 - [2. Schedule a new event](#2-schedule-a-new-event)
   * [Booking](#booking)
 - [3. Announce the event](#3-announce-the-event)
@@ -57,6 +58,8 @@ Each of the steps above are now described in more detail.
 
 CNCF staff is responsible for creating the Cloud Native Community Groups (see the instructions in the [README.md](../README.md) file, but to understand the various admin rights of who can create new groups, please visit the [OCGroups documentation](https://ocgroups.dev/docs#/getting-started/choose-dashboard?id=how-to-pick-the-right-workspace).
 It is useful to create a community slack channel `#cloud-native-<city name>` for event coordination ([CNCF Slack](https://app.slack.com/client/T08PSQ7BQ/C015WPLD3F1)).
+
+Before you start promoting your group, check out [branding.md](./branding.md) for the official logo, naming conventions, and other brand assets.
 
 The **description** of the group is left to the discretion of the organizers.
 
@@ -101,6 +104,12 @@ What to offer the sponsors in return
 * Thank your sponsors by highlighting them in the event settings on your community platform. For specific instructions on managing sponsors and reusable profiles, please refer to the [OCGroups documentation](https://ocgroups.dev/docs#/guides/group-dashboard?id=sponsors-reusable-profiles).
 * Offer your sponsor to set up a small table in our just outside the room, so people can engage in conversation.
 * Offer your sponsor no more than 15 minutes of talking time on the stage. But be sure they are NOT the main content.
+
+#### Sponsor Prospectus
+
+If you need a formal presentation to show, or a PDF to share with a prospecting sponsor, we have created a professional template that highlights common needs for meetups, and what sponsors can get in return.
+
+Feel free to make a copy and edit [this template in Canva](https://www.canva.com/design/DAGSX9KG53Q/8tAN20diaVRFPvIcMWVOYA/edit?utm_content=DAGSX9KG53Q&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton). Make sure the packages match what your team can offer, and images to be based on your past meetups.
 
 ## 2. Schedule a new event
 

--- a/branding.md
+++ b/branding.md
@@ -8,12 +8,6 @@ NOTE: For naming conventions, please use "Cloud Native CITY NAME" for your socia
 
 IMPORTANT: Using the above CNCG logo creates unity across all community groups supported by CNCF, and an offical brand/identity awareness for when organizers try to secure sponsorships.
 
-# Sponsor Prospectus
-
-If you need a formal presentation to show, or a PDF to share with a prospecting sponsor, we have create a professsional template that highlights common needs for meetups, and what sponsors can get in return.
-
-Feel free to make a copy and edit [this template in Canva](https://www.canva.com/design/DAGSX9KG53Q/8tAN20diaVRFPvIcMWVOYA/edit?utm_content=DAGSX9KG53Q&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton). Make sure the packages match what your team can offer, and images to be based on your past meetups.
-
 # Promotional Graphics
 
 Do you need samples of promotional graphics? Here we have some templates in Canva that will at least help you with sizing and placement of key content:


### PR DESCRIPTION
## Overall improvements for new organizers and existing organizers who use as a reference
- Renamed `assets.md` to `branding.md` and linked it from `README`.md's Marketing section
- Expanded `best_practices.md`'s group-creation step, since it was previously an orphaned file with no inbound links. 
- Moved the Sponsor Prospectus content into `best_practices.md`'s Sponsorships section where it fits better
- Deduplicated the drifted promotional-graphics Canva links between `README.md` and `branding.md`
- Expanded README's Best Practices section to preview key sections of `best_practices.md`.